### PR TITLE
fix: enable firecracker seccomp filter in jailer spawn

### DIFF
--- a/agent/csfx-guest-init/src/main.rs
+++ b/agent/csfx-guest-init/src/main.rs
@@ -1,18 +1,18 @@
 use anyhow::{Context, Result};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
-use nix::mount::{mount, MsFlags};
+use nix::mount::{MsFlags, mount};
 use nix::pty::openpty;
-use nix::sys::reboot::{reboot, RebootMode};
-use nix::sys::wait::{waitpid, WaitStatus};
+use nix::sys::reboot::{RebootMode, reboot};
+use nix::sys::wait::{WaitStatus, waitpid};
 use nix::unistd::Pid;
 use serde::Deserialize;
 use std::os::fd::{AsRawFd, OwnedFd};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::time::{timeout, Duration};
-use tokio_vsock::{VsockAddr, VsockListener, VMADDR_CID_ANY};
+use tokio::time::{Duration, timeout};
+use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 use tracing::{debug, error, info, warn};
 
 const LOG_PORT: u32 = 10001;
@@ -70,22 +70,34 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
-    debug!(stage = "mount_pseudo_filesystems", "Mounting pseudo filesystems");
+    debug!(
+        stage = "mount_pseudo_filesystems",
+        "Mounting pseudo filesystems"
+    );
     mount_pseudo_filesystems();
 
-    debug!(stage = "bring_up_interface", iface = "eth0", "Bringing up network interface");
+    debug!(
+        stage = "bring_up_interface",
+        iface = "eth0",
+        "Bringing up network interface"
+    );
     bring_up_interface("eth0").context("Failed to bring up network interface")?;
 
-    debug!(stage = "assign_bootstrap_address", iface = "eth0", "Assigning mmds bootstrap address");
-    assign_bootstrap_address("eth0")
-        .context("Failed to assign mmds bootstrap address")?;
+    debug!(
+        stage = "assign_bootstrap_address",
+        iface = "eth0",
+        "Assigning mmds bootstrap address"
+    );
+    assign_bootstrap_address("eth0").context("Failed to assign mmds bootstrap address")?;
 
     add_host_route(std::net::Ipv4Addr::new(169, 254, 169, 254), "eth0")
         .context("Failed to add mmds route")?;
     info!("mmds route added");
 
     debug!(stage = "fetch_mmds_data", "Fetching mmds data");
-    let mmds_data = fetch_mmds_data().await.context("Failed to fetch mmds data")?;
+    let mmds_data = fetch_mmds_data()
+        .await
+        .context("Failed to fetch mmds data")?;
     debug!(
         stage = "mmds_data_fetched",
         has_network = mmds_data.network.is_some(),
@@ -113,26 +125,40 @@ async fn run() -> Result<()> {
         .context("Failed to bind vsock log port")?;
     let exec_listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, EXEC_PORT))
         .context("Failed to bind vsock exec port")?;
-    debug!(stage = "vsock_listeners_bound", log_port = LOG_PORT, exec_port = EXEC_PORT, "vsock listeners bound");
+    debug!(
+        stage = "vsock_listeners_bound",
+        log_port = LOG_PORT,
+        exec_port = EXEC_PORT,
+        "vsock listeners bound"
+    );
 
-    debug!(stage = "start_container", "Starting container via libcontainer");
+    debug!(
+        stage = "start_container",
+        "Starting container via libcontainer"
+    );
     let (stdout_read, stderr_read, container_pid) = start_container(&mmds_data.env).await?;
-    debug!(stage = "container_started", container_pid = container_pid.as_raw(), "Container process started");
+    debug!(
+        stage = "container_started",
+        container_pid = container_pid.as_raw(),
+        "Container process started"
+    );
 
     let log_task = tokio::spawn(stream_logs(log_listener, stdout_read, stderr_read));
     tokio::spawn(serve_exec(exec_listener));
 
-    let exit_status = tokio::task::spawn_blocking(move || loop {
-        match waitpid(container_pid, None) {
-            Ok(WaitStatus::Exited(pid, code)) if pid == container_pid => {
-                return Ok(WaitStatus::Exited(pid, code))
+    let exit_status = tokio::task::spawn_blocking(move || {
+        loop {
+            match waitpid(container_pid, None) {
+                Ok(WaitStatus::Exited(pid, code)) if pid == container_pid => {
+                    return Ok(WaitStatus::Exited(pid, code));
+                }
+                Ok(WaitStatus::Signaled(pid, sig, core)) if pid == container_pid => {
+                    return Ok(WaitStatus::Signaled(pid, sig, core));
+                }
+                Ok(_) => continue,
+                Err(nix::errno::Errno::EINTR) => continue,
+                Err(e) => return Err(e),
             }
-            Ok(WaitStatus::Signaled(pid, sig, core)) if pid == container_pid => {
-                return Ok(WaitStatus::Signaled(pid, sig, core))
-            }
-            Ok(_) => continue,
-            Err(nix::errno::Errno::EINTR) => continue,
-            Err(e) => return Err(e),
         }
     })
     .await
@@ -155,8 +181,8 @@ fn apply_extra_env(extra_env: &std::collections::HashMap<String, String>) -> Res
     }
 
     let config_path = std::path::Path::new(CONTAINER_BUNDLE_PATH).join("config.json");
-    let mut spec =
-        oci_spec::runtime::Spec::load(&config_path).context("Failed to load runtime config.json")?;
+    let mut spec = oci_spec::runtime::Spec::load(&config_path)
+        .context("Failed to load runtime config.json")?;
 
     let process = spec
         .process_mut()
@@ -178,8 +204,10 @@ async fn start_container(
     apply_extra_env(extra_env).context("Failed to apply mmds env to container config")?;
     write_container_etc_hosts();
 
-    let (stdout_read, stdout_write) = nix::unistd::pipe().context("Failed to create stdout pipe")?;
-    let (stderr_read, stderr_write) = nix::unistd::pipe().context("Failed to create stderr pipe")?;
+    let (stdout_read, stdout_write) =
+        nix::unistd::pipe().context("Failed to create stdout pipe")?;
+    let (stderr_read, stderr_write) =
+        nix::unistd::pipe().context("Failed to create stderr pipe")?;
 
     set_nonblocking(&stdout_read).context("Failed to set stdout pipe non-blocking")?;
     set_nonblocking(&stderr_read).context("Failed to set stderr pipe non-blocking")?;
@@ -198,7 +226,9 @@ async fn start_container(
 
         container.start().context("Failed to start container")?;
 
-        let libcontainer_pid = container.pid().context("Container has no pid after start")?;
+        let libcontainer_pid = container
+            .pid()
+            .context("Container has no pid after start")?;
         Ok(Pid::from_raw(libcontainer_pid.as_raw()))
     })
     .await
@@ -215,7 +245,9 @@ fn dump_failure_diagnostics() {
     let config_path = std::path::Path::new(CONTAINER_BUNDLE_PATH).join("config.json");
     match std::fs::read_to_string(&config_path) {
         Ok(contents) => warn!(config = %contents, "debug: container config.json on failure"),
-        Err(e) => warn!(error = ?e, path = ?config_path, "debug: failed to read config.json on failure"),
+        Err(e) => {
+            warn!(error = ?e, path = ?config_path, "debug: failed to read config.json on failure")
+        }
     }
 
     match std::fs::read_to_string("/proc/self/mountinfo") {
@@ -280,8 +312,13 @@ fn assign_bootstrap_address(iface: &str) -> Result<()> {
     let result = (|| -> Result<()> {
         set_ifreq_addr(socket_fd, iface, libc::SIOCSIFADDR, MMDS_BOOTSTRAP_IP)
             .context("SIOCSIFADDR failed")?;
-        set_ifreq_addr(socket_fd, iface, libc::SIOCSIFNETMASK, MMDS_BOOTSTRAP_NETMASK)
-            .context("SIOCSIFNETMASK failed")?;
+        set_ifreq_addr(
+            socket_fd,
+            iface,
+            libc::SIOCSIFNETMASK,
+            MMDS_BOOTSTRAP_NETMASK,
+        )
+        .context("SIOCSIFNETMASK failed")?;
         Ok(())
     })();
 
@@ -349,15 +386,18 @@ fn write_resolv_conf(dns: &str) -> Result<()> {
         .join("etc/resolv.conf");
     std::fs::create_dir_all(container_resolv_conf.parent().unwrap())
         .context("Failed to create container /etc")?;
-    std::fs::write(&container_resolv_conf, &contents)
-        .context("Failed to write resolv.conf")
+    std::fs::write(&container_resolv_conf, &contents).context("Failed to write resolv.conf")
 }
 
 fn prefix_to_netmask(prefix: u32) -> Result<std::net::Ipv4Addr> {
     if prefix > 32 {
         anyhow::bail!("invalid prefix length {}", prefix);
     }
-    let bits: u32 = if prefix == 0 { 0 } else { !0u32 << (32 - prefix) };
+    let bits: u32 = if prefix == 0 {
+        0
+    } else {
+        !0u32 << (32 - prefix)
+    };
     Ok(std::net::Ipv4Addr::from(bits))
 }
 
@@ -452,21 +492,6 @@ fn ipv4_to_sockaddr(addr: std::net::Ipv4Addr) -> libc::sockaddr_in {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn sockaddr_holds_octets_in_network_order() {
-        let sockaddr = ipv4_to_sockaddr(std::net::Ipv4Addr::new(169, 254, 169, 2));
-        assert_eq!(sockaddr.sin_addr.s_addr.to_ne_bytes(), [169, 254, 169, 2]);
-        assert_eq!(sockaddr.sin_family, libc::AF_INET as libc::sa_family_t);
-
-        let netmask = ipv4_to_sockaddr(prefix_to_netmask(16).unwrap());
-        assert_eq!(netmask.sin_addr.s_addr.to_ne_bytes(), [255, 255, 0, 0]);
-    }
-}
-
 fn ipv4_to_sockaddr_storage(addr: std::net::Ipv4Addr) -> libc::sockaddr {
     let sockaddr_in = ipv4_to_sockaddr(addr);
     let mut sockaddr: libc::sockaddr = unsafe { std::mem::zeroed() };
@@ -519,7 +544,12 @@ async fn read_http_body(stream: &mut TcpStream) -> Result<String> {
     let header_text = String::from_utf8_lossy(&buf[..header_end]);
     let content_length: usize = header_text
         .lines()
-        .find_map(|line| line.to_lowercase().strip_prefix("content-length:").map(str::trim).map(str::to_string))
+        .find_map(|line| {
+            line.to_lowercase()
+                .strip_prefix("content-length:")
+                .map(str::trim)
+                .map(str::to_string)
+        })
         .context("mmds response missing content-length")?
         .parse()
         .context("mmds response has invalid content-length")?;
@@ -565,16 +595,43 @@ fn mount_volume(volume: &MmdsVolume) -> Result<()> {
         }
     }
 
-    anyhow::bail!("failed to mount device {} with any known filesystem type", volume.device)
+    anyhow::bail!(
+        "failed to mount device {} with any known filesystem type",
+        volume.device
+    )
 }
 
 fn mount_pseudo_filesystems() {
     let mounts: &[(&str, &str, &str, MsFlags, Option<&str>)] = &[
-        ("proc", "/proc", "proc", MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC, None),
-        ("sysfs", "/sys", "sysfs", MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC, None),
+        (
+            "proc",
+            "/proc",
+            "proc",
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC,
+            None,
+        ),
+        (
+            "sysfs",
+            "/sys",
+            "sysfs",
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC,
+            None,
+        ),
         ("devtmpfs", "/dev", "devtmpfs", MsFlags::MS_NOSUID, None),
-        ("devpts", "/dev/pts", "devpts", MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC, Some("mode=0620,ptmxmode=0666,gid=5")),
-        ("cgroup2", "/sys/fs/cgroup", "cgroup2", MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC, None),
+        (
+            "devpts",
+            "/dev/pts",
+            "devpts",
+            MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+            Some("mode=0620,ptmxmode=0666,gid=5"),
+        ),
+        (
+            "cgroup2",
+            "/sys/fs/cgroup",
+            "cgroup2",
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC,
+            None,
+        ),
     ];
 
     for (source, target, fstype, flags, data) in mounts {
@@ -730,20 +787,25 @@ fn set_nonblocking(fd: &OwnedFd) -> Result<()> {
 
 async fn exec_shell_in_container(slave: OwnedFd) -> Result<Pid> {
     tokio::task::spawn_blocking(move || -> Result<Pid> {
-        let stdin = slave.try_clone().context("Failed to clone pty slave for stdin")?;
-        let stdout = slave.try_clone().context("Failed to clone pty slave for stdout")?;
+        let stdin = slave
+            .try_clone()
+            .context("Failed to clone pty slave for stdin")?;
+        let stdout = slave
+            .try_clone()
+            .context("Failed to clone pty slave for stdout")?;
 
-        let libcontainer_pid = ContainerBuilder::new(CONTAINER_ID.to_string(), SyscallType::default())
-            .with_root_path(CONTAINER_STATE_ROOT)
-            .context("Invalid container state root path")?
-            .with_stdin(stdin)
-            .with_stdout(stdout)
-            .with_stderr(slave)
-            .as_tenant()
-            .with_container_args(vec!["sh".to_string()])
-            .with_detach(true)
-            .build()
-            .context("Failed to exec into container")?;
+        let libcontainer_pid =
+            ContainerBuilder::new(CONTAINER_ID.to_string(), SyscallType::default())
+                .with_root_path(CONTAINER_STATE_ROOT)
+                .context("Invalid container state root path")?
+                .with_stdin(stdin)
+                .with_stdout(stdout)
+                .with_stderr(slave)
+                .as_tenant()
+                .with_container_args(vec!["sh".to_string()])
+                .with_detach(true)
+                .build()
+                .context("Failed to exec into container")?;
 
         Ok(Pid::from_raw(libcontainer_pid.as_raw()))
     })
@@ -806,7 +868,11 @@ async fn read_pty(master: &AsyncFd<OwnedFd>, buf: &mut [u8]) -> std::io::Result<
         let mut guard = master.readable().await?;
         match guard.try_io(|fd| {
             let n = unsafe {
-                libc::read(fd.as_raw_fd(), buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+                libc::read(
+                    fd.as_raw_fd(),
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    buf.len(),
+                )
             };
             if n < 0 {
                 Err(std::io::Error::last_os_error())
@@ -844,4 +910,19 @@ async fn write_pty(master: &AsyncFd<OwnedFd>, buf: &[u8]) -> std::io::Result<()>
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sockaddr_holds_octets_in_network_order() {
+        let sockaddr = ipv4_to_sockaddr(std::net::Ipv4Addr::new(169, 254, 169, 2));
+        assert_eq!(sockaddr.sin_addr.s_addr.to_ne_bytes(), [169, 254, 169, 2]);
+        assert_eq!(sockaddr.sin_family, libc::AF_INET as libc::sa_family_t);
+
+        let netmask = ipv4_to_sockaddr(prefix_to_netmask(16).unwrap());
+        assert_eq!(netmask.sin_addr.s_addr.to_ne_bytes(), [255, 255, 0, 0]);
+    }
 }

--- a/agent/src/firecracker/rootfs.rs
+++ b/agent/src/firecracker/rootfs.rs
@@ -5,7 +5,7 @@ use oci_client::config::ConfigFile;
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, Reference};
 use oci_spec::runtime::{
-    get_default_namespaces, Capability, Capabilities, LinuxBuilder, LinuxCapabilitiesBuilder,
+    get_default_namespaces, Capabilities, Capability, LinuxBuilder, LinuxCapabilitiesBuilder,
     LinuxNamespaceType, ProcessBuilder, RootBuilder, Spec, SpecBuilder, User, UserBuilder,
 };
 use std::path::{Path, PathBuf};
@@ -146,13 +146,19 @@ impl RootfsBuilder {
                 .context("Failed to extract image layer")?;
         }
 
-        debug!(stage = "write_runtime_config", "Writing OCI runtime config.json");
+        debug!(
+            stage = "write_runtime_config",
+            "Writing OCI runtime config.json"
+        );
         write_runtime_config(&image_data.config.data, &bundle_dir).await?;
 
         debug!(stage = "install_guest_init", "Installing guest-init binary");
         install_guest_init(extract_dir).await?;
 
-        debug!(stage = "create_root_dirs", "Creating standard guest root directories");
+        debug!(
+            stage = "create_root_dirs",
+            "Creating standard guest root directories"
+        );
         create_guest_root_dirs(extract_dir).await?;
 
         Ok(())

--- a/agent/src/firecracker/runtime.rs
+++ b/agent/src/firecracker/runtime.rs
@@ -93,7 +93,11 @@ fn vsock_uds_path(chroot_dir: &Path, workload_id: &str) -> PathBuf {
     jailer_vm_root_dir(chroot_dir, &jailer_id).join(format!("{}.vsock", API_SOCKET_NAME))
 }
 
-async fn connect_guest_vsock(chroot_dir: &Path, workload_id: &str, port: u32) -> Result<UnixStream> {
+async fn connect_guest_vsock(
+    chroot_dir: &Path,
+    workload_id: &str,
+    port: u32,
+) -> Result<UnixStream> {
     let uds_path = vsock_uds_path(chroot_dir, workload_id);
 
     let mut stream = UnixStream::connect(&uds_path)
@@ -495,12 +499,14 @@ impl crate::runtime::Runtime for FirecrackerRuntime {
             };
             let cpu_usage_percent = read_cpu_usage_percent(handle).await;
             let memory_usage_bytes = read_memory_usage_bytes(&handle.cgroup_path).await;
-            (cpu_usage_percent, memory_usage_bytes, handle.metrics_path.clone())
+            (
+                cpu_usage_percent,
+                memory_usage_bytes,
+                handle.metrics_path.clone(),
+            )
         };
 
-        let (network_rx_bytes, network_tx_bytes) = read_network_bytes(&metrics_path)
-            .await
-            .unzip();
+        let (network_rx_bytes, network_tx_bytes) = read_network_bytes(&metrics_path).await.unzip();
 
         Ok(crate::runtime::ContainerStats {
             cpu_usage_percent,
@@ -1043,7 +1049,12 @@ async fn configure_and_boot_vm(
     let vcpu_count = ((spec.cpu_millicores.max(100)) as f64 / 1000.0).ceil() as i64;
     let mem_size_mib = (spec.memory_bytes / 1024 / 1024).max(128);
 
-    debug!(vcpu_count = vcpu_count, mem_size_mib = mem_size_mib, stage = "machine_config", "Configuring machine");
+    debug!(
+        vcpu_count = vcpu_count,
+        mem_size_mib = mem_size_mib,
+        stage = "machine_config",
+        "Configuring machine"
+    );
     client
         .put(
             "/machine-config",
@@ -1101,7 +1112,10 @@ async fn configure_and_boot_vm(
     )
     .await?;
 
-    debug!(stage = "network_interface_config", "Configuring network interface");
+    debug!(
+        stage = "network_interface_config",
+        "Configuring network interface"
+    );
     client
         .put(
             "/network-interfaces/eth0",
@@ -1112,7 +1126,11 @@ async fn configure_and_boot_vm(
         )
         .await?;
 
-    debug!(vsock_cid = boot_config.vsock_cid, stage = "vsock_config", "Configuring vsock device");
+    debug!(
+        vsock_cid = boot_config.vsock_cid,
+        stage = "vsock_config",
+        "Configuring vsock device"
+    );
     client
         .put(
             "/vsock",
@@ -1137,7 +1155,10 @@ async fn configure_and_boot_vm(
         .put("/actions", &json!({ "action_type": "InstanceStart" }))
         .await?;
 
-    debug!(stage = "instance_started", "InstanceStart accepted by Firecracker");
+    debug!(
+        stage = "instance_started",
+        "InstanceStart accepted by Firecracker"
+    );
 
     Ok(())
 }

--- a/agent/src/firecracker/runtime.rs
+++ b/agent/src/firecracker/runtime.rs
@@ -810,7 +810,6 @@ async fn spawn_jailer(
             "--",
             "--api-sock",
             api_socket,
-            "--no-seccomp",
         ])
         .status()
         .await

--- a/agent/src/rbd.rs
+++ b/agent/src/rbd.rs
@@ -56,4 +56,3 @@ pub async fn map_device(pool: &str, image: &str) -> Result<String> {
     info!(device = %device, "RBD device mapped");
     Ok(device)
 }
-

--- a/control-plane/api-gateway/src/routes/resource_groups.rs
+++ b/control-plane/api-gateway/src/routes/resource_groups.rs
@@ -231,7 +231,9 @@ pub async fn suggest_cidr(
             let [a, b, c, d] = network.to_be_bytes();
             return Ok((
                 StatusCode::OK,
-                Json(json!({ "internal_cidr": format!("{}.{}.{}.{}/{}", a, b, c, d, SUGGESTED_CIDR_PREFIX) })),
+                Json(
+                    json!({ "internal_cidr": format!("{}.{}.{}.{}/{}", a, b, c, d, SUGGESTED_CIDR_PREFIX) }),
+                ),
             ));
         }
     }

--- a/control-plane/scheduler/src/db/workloads.rs
+++ b/control-plane/scheduler/src/db/workloads.rs
@@ -150,7 +150,10 @@ pub async fn get_by_stack_id(
         .await
 }
 
-pub async fn delete_by_stack_id(db: &DatabaseConnection, stack_id: Uuid) -> Result<(), sea_orm::DbErr> {
+pub async fn delete_by_stack_id(
+    db: &DatabaseConnection,
+    stack_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
     workloads::Entity::delete_many()
         .filter(workloads::Column::StackId.eq(stack_id))
         .exec(db)

--- a/control-plane/scheduler/src/handlers/stacks.rs
+++ b/control-plane/scheduler/src/handlers/stacks.rs
@@ -25,10 +25,7 @@ pub async fn create_stack(
     }
 }
 
-pub async fn get_stack(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-) -> impl IntoResponse {
+pub async fn get_stack(State(state): State<AppState>, Path(id): Path<Uuid>) -> impl IntoResponse {
     match crate::db::workload_stacks::get_by_id(&state.db, id).await {
         Ok(Some(model)) => (
             StatusCode::OK,
@@ -66,10 +63,7 @@ pub async fn delete_stack(
     }
 }
 
-pub async fn stop_stack(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-) -> impl IntoResponse {
+pub async fn stop_stack(State(state): State<AppState>, Path(id): Path<Uuid>) -> impl IntoResponse {
     match state.scheduler.stop_stack(id).await {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (

--- a/control-plane/scheduler/src/handlers/workloads.rs
+++ b/control-plane/scheduler/src/handlers/workloads.rs
@@ -79,9 +79,7 @@ pub async fn update_workload(
     match db::workloads::update_spec(&state.db, id, &req).await {
         Ok(model) => {
             if let Some(agent_id) = model.assigned_agent_id {
-                tokio::spawn(crate::services::gateway_notify::notify_assignment(
-                    agent_id,
-                ));
+                tokio::spawn(crate::services::gateway_notify::notify_assignment(agent_id));
             }
             (StatusCode::OK, Json(serde_json::json!(model))).into_response()
         }

--- a/control-plane/scheduler/src/services/scheduler.rs
+++ b/control-plane/scheduler/src/services/scheduler.rs
@@ -225,13 +225,9 @@ impl SchedulerService {
         Ok(())
     }
 
-    pub async fn redeploy_stack(
-        &self,
-        stack_id: Uuid,
-        compose_yaml: &str,
-    ) -> Result<(), String> {
-        let services = compose_parser::parse_compose(compose_yaml)
-            .map_err(|e| format_compose_error(&e))?;
+    pub async fn redeploy_stack(&self, stack_id: Uuid, compose_yaml: &str) -> Result<(), String> {
+        let services =
+            compose_parser::parse_compose(compose_yaml).map_err(|e| format_compose_error(&e))?;
 
         let existing = crate::db::workloads::get_by_stack_id(&self.db, stack_id)
             .await


### PR DESCRIPTION
Removes --no-seccomp from the jailer invocation, which silenced firecracker's default syscall filter and produced a WARN log on every microVM start. Requires host kernel CONFIG_SECCOMP_FILTER=y (default on NixOS).