### PR TITLE
fix: correct cgroup path to jailer systemd scope

### DIFF
--- a/agent/src/firecracker/runtime.rs
+++ b/agent/src/firecracker/runtime.rs
@@ -910,9 +910,10 @@ fn create_metrics_fifo(path: &Path) -> Result<()> {
 }
 
 fn cgroup_path(workload_id: &str) -> PathBuf {
+    let unit_name = jailer_unit_name(&jailer_short_id(workload_id));
     Path::new(CGROUP_ROOT)
-        .join(CGROUP_PARENT)
-        .join(jailer_short_id(workload_id))
+        .join("system.slice")
+        .join(format!("{}.service", unit_name))
 }
 
 async fn apply_port_dnat(workload_id: &str, guest_ip: &str, spec: &WorkloadSpec) -> Result<()> {


### PR DESCRIPTION
The jailer does not create a cgroup under /sys/fs/cgroup/csfx-firecracker/<id> as previously assumed (fixed in #214). It inherits the cgroup that systemd-run already created for the transient unit: /sys/fs/cgroup/system.slice/csfx-jailer-<id>.service/. Confirmed on the running server via find and cgroup.procs.

Path corrected to derive from jailer_unit_name instead. No functional change beyond the path construction.