### PR TITLE
fix: log vsock accept guard blocks reconnects after first client

### DIFF
--- a/agent/csfx-guest-init/src/main.rs
+++ b/agent/csfx-guest-init/src/main.rs
@@ -676,7 +676,7 @@ async fn stream_logs(listener: VsockListener, stdout: AsyncFd<OwnedFd>, stderr: 
 
     while stdout_open || stderr_open {
         tokio::select! {
-            accept_result = listener.accept(), if client.is_none() => {
+            accept_result = listener.accept() => {
                 match accept_result {
                     Ok((conn, addr)) => {
                         info!(target: "workload.logstream", peer = ?addr, "log client accepted");


### PR DESCRIPTION
Root cause of logs staying empty in the frontend even after #213/#214 landed.

stream_logs in csfx-guest-init only calls listener.accept() while client.is_none(). Once one client connects, that branch of the select! never fires again until a write to the stale client fails — which only happens on the next log line produced. If the agent side reconnects (browser tab reload, gateway retry, etc.) before another log line is written, guest-init never pulls the new connection off the accept queue: the vsock handshake succeeds at the kernel level (agent logs guest log vsock connected), but nobody on the guest side ever reads or writes on it, so the stream sits open with zero bytes forever — exactly the symptom (log client accepted logged once, but the agent shows 5 separate connect attempts, only 1 of which was actually accepted).

Fix: drop the is_none() guard so a new connection always replaces whatever was there, dead or not.